### PR TITLE
Use plenary.job until vim.system is on stable

### DIFF
--- a/lua/asset-bender.lua
+++ b/lua/asset-bender.lua
@@ -201,7 +201,6 @@ function M.getTsServerPathForCurrentFile()
 		-- Returns the Path, Filename, and Extension as 3 values
 		return string.match(strFilename, "(.-)([^\\]-([^\\%.]+))$")
 	end
-
 	local bufnr = vim.api.nvim_get_current_buf()
 	local path = vim.api.nvim_buf_get_name(bufnr)
 

--- a/lua/asset-bender.lua
+++ b/lua/asset-bender.lua
@@ -235,8 +235,8 @@ function M.getTsServerPathForCurrentFile()
 	log.trace(
 		"asset-bender-tsserver-notification",
 		"node_modules found at "
-		.. directoryOfNodeModules
-		.. " - will parse the package.json in that directory for the hs-typescript version"
+			.. directoryOfNodeModules
+			.. " - will parse the package.json in that directory for the hs-typescript version"
 	)
 
 	local pathOfPackageJson = path_join(directoryOfNodeModules, "package.json")


### PR DESCRIPTION
👋 I am using the latest stable nvim `9.4` which does not yet support `vim.system`.
This PR swaps those calls over to `plenary.Job` which has identical functionality.